### PR TITLE
Use alpine as base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM remind101/go:1.4
+FROM alpine:3.1
 MAINTAINER Eric Holmes <eric@remind101.com>
 
-WORKDIR /go/src/github.com/remind101/acme-inc
 COPY ./ /go/src/github.com/remind101/acme-inc
-RUN go install ./...
-ENTRYPOINT ["/go/bin/acme-inc"]
+COPY ./bin/build /build
+RUN /build
+WORKDIR /go/src/github.com/remind101/acme-inc
 
-EXPOSE 8080
+CMD ["acme-inc"]

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+packages="curl go git"
+
+apk add --update $packages
+
+GOPATH=/go go install github.com/remind101/acme-inc
+mv /go/bin/acme-inc /bin
+
+apk del $packages
+rm -rf /var/cache/apk/*


### PR DESCRIPTION
This results in an 11mb image, making it more suitable for quickly testing empire.

```
REPOSITORY           TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
remind101/acme-inc   latest              d34255425129        2 minutes ago       11.17 MB
```
