### PR TITLE
Use go1.4.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: build
 
 build:
-	docker build -t remind101/acme-inc .
+	docker build --no-cache -t remind101/acme-inc .

--- a/bin/build
+++ b/bin/build
@@ -1,11 +1,12 @@
 #!/bin/sh
 
-packages="curl go git"
+echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+packages="curl git go@edge"
 
-apk add --update $packages
+apk add --update curl git go@edge
 
 GOPATH=/go go install github.com/remind101/acme-inc
 mv /go/bin/acme-inc /bin
 
-apk del $packages
+apk del curl git go
 rm -rf /var/cache/apk/*


### PR DESCRIPTION
Still results in an 11mb image, but uses go 1.4.
